### PR TITLE
Fix bug when reading the aXo_file

### DIFF
--- a/ocean_model.F90
+++ b/ocean_model.F90
@@ -289,7 +289,7 @@ contains
        nfile_axo = siz(2)
        rmask = 0.0
        do n = 1, nfile_axo
-          call read_data(grid_fileobj, "aXo_file", axo_file, unlim_dim_level=n)
+          call read_data(grid_fileobj, "aXo_file", axo_file, corner=n)
           axo_file = 'INPUT/'//trim(axo_file)
           if ( .not. open_file(axo_fileobj, axo_file, "read")) then
              call mpp_error(FATAL, 'ocean_model_init: error opening '//trim(axo_file))


### PR DESCRIPTION
Fix a bug when reading the aXo_file.

This was tested with the coupler build: https://github.com/NOAA-GFDL/FMScoupler/blob/main/t/null_model_build.sh
It was crashing before the fix with:

```
FATAL: unlimited dimension must be the slowest varying dimension: netcdf_read_data_0d: file:INPUT/grid_spec.nc- variable:aXo_file

Image              PC                Routine            Line        Source             
coupler_full_test  0000000000654C66  mpp_mod_mp_mpp_er          72  mpp_util_mpi.inc
coupler_full_test  0000000000B743BF  fms_io_utils_mod_         190  fms_io_utils.F90
coupler_full_test  0000000000A8F5E7  netcdf_io_mod_mp_          68  netcdf_read_data.inc
coupler_full_test  0000000000AB2604  netcdf_io_mod_mp_          44  compressed_read.inc
coupler_full_test  00000000004AA97E  ocean_model_mod_m         292  ocean_model.F90
coupler_full_test  000000000041A235  coupler_main_IP_c        1750  coupler_main.F90
coupler_full_test  0000000000411BBB  MAIN__                    589  coupler_main.F90
coupler_full_test  000000000041187D  Unknown               Unknown  Unknown
libc-2.28.so       00007F3780B22D85  __libc_start_main     Unknown  Unknown
coupler_full_test  000000000041179E  Unknown               Unknown  Unknown

```
